### PR TITLE
feat(zsh): Add nb and ghq integration with fzf keybindings

### DIFF
--- a/config/zsh/bindkey.zsh
+++ b/config/zsh/bindkey.zsh
@@ -1,5 +1,13 @@
 autoload -Uz edit-command-line
 zle -N edit-command-line
 bindkey "^O" edit-command-line
-bindkey "^G" _ghq_src
-bindkey "^XG" list-expand
+
+if command -v ghq >/dev/null; then
+  bindkey "^G" _ghq_src
+  bindkey "^XG" list-expand
+fi
+
+if command -v nb >/dev/null; then
+  bindkey "^E^E" _nb_notes
+  bindkey "^E^T" _nb_tags
+fi

--- a/config/zsh/function.zsh
+++ b/config/zsh/function.zsh
@@ -17,6 +17,7 @@
 # zle -N _task_add_nvim
 # bindkey '^O' _task_add_nvim
 
+## ghq
 _ghq_src() {
   local selected_dir=$(ghq list | fzf --prompt="repo > " --layout="reverse" --query="$LBUFFER")
   if [ -n "$selected_dir" ]; then
@@ -26,3 +27,44 @@ _ghq_src() {
   zle clear-screen
 }
 zle -N _ghq_src
+
+## mb notes
+_nb_notes() {
+  local selected_note=$(nb list --no-color | fzf --prompt="Select note > " --layout="reverse")
+  if [ -z "$selected_note" ]; then
+    echo "No note selected"
+    zle reset-prompt
+    return 1
+  fi
+
+  local selected_note_id=$(echo "$selected_note" | sed -E 's/^[^[]*\[([^]]+)\].*$/\1/')
+  BUFFER="nb edit $selected_note_id"
+  zle accept-line
+  zle clear-screen
+}
+zle -N _nb_notes
+
+## nb tags
+_nb_tags() {
+  local tags=$(nb --no-color --tags | sed 's/^#//g')
+  local selected_tag=$(echo "$tags" | fzf --prompt="Select tag > " --layout="reverse")
+  if [ -z "$selected_tag" ]; then
+    echo "No tag selected"
+    zle reset-prompt
+    return 1
+  fi
+
+  local notes=$(nb --no-color --tag "$selected_tag")
+  local selected_note=$(echo "$notes" | fzf --prompt="Select note > " --layout="reverse")
+  if [ -z "$selected_note" ]; then
+    echo "No note selected"
+    zle reset-prompt
+    return 1
+  fi
+
+  local selected_note_id=$(echo "$selected_note" | sed -E 's/^[^[]*\[([^]]+)\].*$/\1/')
+  BUFFER="nb edit $selected_note_id"
+  zle accept-line
+  zle clear-screen
+}
+zle -N _nb_tags


### PR DESCRIPTION
This commit introduces new zsh keybindings and functions to improve integration with:
- `nb`: A note-taking tool. Users can now browse and edit notes by tag using `^E^T`.
- `ghq`: A tool for managing Git repositories. The existing `ghq` keybindings (`^G` and `^XG`) are now conditional on `ghq` being installed.

Both integrations leverage `fzf` for interactive selection.