### PR TITLE
feat(nvim): Configure plugins and add nb.nvim search keybinding

### DIFF
--- a/config/nvim/lua/config/plugins/copilot.lua
+++ b/config/nvim/lua/config/plugins/copilot.lua
@@ -6,6 +6,7 @@ local M = {
   cmd = "Copilot",
   event = "InsertEnter",
   opts = {},
+  enabled = true,
 }
 
 return M

--- a/config/nvim/lua/config/plugins/nb.lua
+++ b/config/nvim/lua/config/plugins/nb.lua
@@ -11,8 +11,9 @@ local M = {
   keys = {
     { "<Leader>oq", "<Cmd>Nb notes<CR>", mode = { "n" } },
     { "<Leader>ot", "<Cmd>Nb tags notes<CR>", mode = { "n" } },
+    { "<Leader>os", "<Cmd>Nb search<CR>", mode = { "n" } },
   },
-  dev = true,
+  dev = false,
 }
 
 return M

--- a/config/nvim/lua/config/plugins/sidekick.lua
+++ b/config/nvim/lua/config/plugins/sidekick.lua
@@ -104,6 +104,7 @@ local M = {
       desc = "Sidekick Select Prompt",
     },
   },
+  enabled = true,
 }
 
 return M


### PR DESCRIPTION
- Enable Copilot and Sidekick plugins by setting .
- Add  keybinding for  in .
- Set  for  to disable development mode.
